### PR TITLE
Handle redis connection failure

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,26 @@
+import sys
 from collections import namedtuple
+from logbook import Logger, StreamHandler
+
+
+StreamHandler(sys.stdout).push_application()
+log = Logger(__name__)
+
+cache_server_up = True
+
+
+def get_cache_state():
+    global cache_server_up
+    return cache_server_up
+
+
+def set_cache_state(state):
+    """
+    Updates current cache server per session
+    :type state: bool
+    """
+    global cache_server_up
+    cache_server_up = state
 
 backslash_url = "https://backslash.infinidat.com/"
 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tempfile
 from itertools import chain
 
@@ -7,14 +6,12 @@ import arrow
 import baker
 import requests
 from backslash import Backslash
-from logbook import Logger, StreamHandler
 from urlobject import URLObject
 
 import config
 from cache_client import add_to_cache, get_from_cache, update_cache
+from config import log
 
-StreamHandler(sys.stdout).push_application()
-log = Logger(__name__)
 
 
 class InternalTest(object):
@@ -221,6 +218,7 @@ def query_errors(test):
         return errors
     log.info(f"Test {test.id} doesn't contain errors'")
     return []
+
 
 def add_errors_to_cache(errors, test):
     """


### PR DESCRIPTION
1. Move log definition to config, instead of utils module, to allow global access to all
2. Add try/except for redis connection, in case o failure, issue an error and update a global floag in the config that redis is not available